### PR TITLE
fix: prevent bitcoind v22 from trodding on bch port

### DIFF
--- a/config/consts.js
+++ b/config/consts.js
@@ -39,7 +39,7 @@ const CRYPTOS = [
     code: 'bitcoincash',
     configFile: 'bitcoincash.conf',
     daemon: 'bitcoincashd',
-    defaultPort: 8335,
+    defaultPort: 8336,
     unitScale: 8,
     zeroConf: true,
     type: 'coin',


### PR DESCRIPTION
https://github.com/lamassu/lamassu-server/pull/1075